### PR TITLE
Updated create-pull-request version

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -33,7 +33,7 @@ jobs:
             --skip-validate-spec
             -o .
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3.3.0
+        uses: peter-evans/create-pull-request@v5.0.0
         with:
           commit-message: Regenerates API Bindings
           title: "OpenAPI: Regenerates API Bindings"


### PR DESCRIPTION
The github action to run the OpenAPI generator is failing because of an old version of create-pull-request.